### PR TITLE
Adding a default value for displaying max_accel_to_decel

### DIFF
--- a/printer.py
+++ b/printer.py
@@ -436,7 +436,7 @@ class PrinterData:
 		self.Y_MAX_POS = int(volume[1])
 		self.max_velocity           = toolhead['max_velocity']
 		self.max_accel              = toolhead['max_accel']
-		self.max_accel_to_decel     = toolhead['max_accel_to_decel']
+		self.max_accel_to_decel     = toolhead.get('max_accel_to_decel', -1)
 		self.square_corner_velocity = toolhead['square_corner_velocity']
 
 	def get_gcode_store(self, count=100):


### PR DESCRIPTION
[max_accel_to_decel](https://www.klipper3d.org/Config_Changes.html) is being deprecated from Klipper and is being included in fewer and fewer default printer.cfg's accordingly.

The proposed is a _**hot-fix**_ to allow KlipperLCD to run on machines without max_accel_to_decel in the config.

The implemented uses the `get` function of the `dictionary` type so that a default value can be retrieved if it doesn't exist within the dict.


(image of KlipperLCD crashing, without the changes)
![image](https://github.com/joakimtoe/KlipperLCD/assets/8618504/79aacbf0-c656-4f7a-8866-5e1acb82ff26)

(adding a pic of the code, I don't know why :) )
![For Some Reason, I'm adding a picture of my code too](https://github.com/joakimtoe/KlipperLCD/assets/8618504/25db7802-1ac9-4f3d-b6c6-0ff226ce1e92)

(image showing KlipperLCD not crashing)
![image](https://github.com/joakimtoe/KlipperLCD/assets/8618504/28743840-8574-4376-90c9-1de0d6f03093)
